### PR TITLE
[Refactor] 관리자 반품 목록 조회 API 개선 (DTO 도입, 키워드 검색 추가)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ build/
 http/req.http
 src/main/resources/test.sql
 src/main/resources/application-local.properties
+.DS_Store
 
 

--- a/src/main/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/controller/RefundAdminController.java
+++ b/src/main/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/controller/RefundAdminController.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.Book2OnAndOn_order_payment_service.order.controller;
 
+import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundSearchCondition;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.response.RefundResponseDto;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundStatusUpdateRequestDto;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.entity.refund.RefundStatus;
@@ -23,30 +24,14 @@ public class RefundAdminController {
 
     // 관리자 반품 목록 조회
     // GET /admin/refunds?status=0&startDate=2025-01-01&endDate=2025-01-31&userId=1&orderNumber=2025123456789&includeGuest=true&page=0&size=20
+    // [변경사항] 위 파라미터를 Dto로 감쌈!
     @GetMapping
     public ResponseEntity<Page<RefundResponseDto>> getRefundList(
-            @RequestParam(name = "status", required = false) Integer refundStatus,
-            @RequestParam(name = "startDate", required = false) LocalDate startDate,
-            @RequestParam(name = "endDate", required = false) LocalDate endDate,
-            @RequestParam(name = "userId", required = false) Long userId,
-            @RequestParam(name = "userKeyword", required = false) String userKeyword,
-            @RequestParam(name = "orderNumber", required = false) String orderNumber,
-            @RequestParam(name = "includeGuest", defaultValue = "true") boolean includeGuest,
+            @ModelAttribute RefundSearchCondition condition,
             Pageable pageable
     ) {
-        RefundStatus status = refundStatus != null ? RefundStatus.fromCode(refundStatus) : null;
-
         return ResponseEntity.ok(
-                refundService.getRefundListForAdmin(
-                        status,
-                        startDate,
-                        endDate,
-                        userId,
-                        userKeyword,
-                        orderNumber,
-                        includeGuest,
-                        pageable
-                )
+                refundService.getRefundListForAdmin(condition, pageable)
         );
     }
 

--- a/src/main/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/dto/refund/request/RefundSearchCondition.java
+++ b/src/main/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/dto/refund/request/RefundSearchCondition.java
@@ -1,0 +1,34 @@
+package com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request;
+
+import com.nhnacademy.Book2OnAndOn_order_payment_service.order.entity.refund.RefundStatus;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class RefundSearchCondition {
+    private Integer status;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    private Long userId;
+    private String userKeyword;
+    private String orderNumber;
+
+    // 기본값 true 설정(기존 코드에 defaultValue="true"
+    private boolean includeGuest = true;
+
+    public RefundStatus getRefundStatusEnum(){
+        return this.status != null ? RefundStatus.fromCode(this.status) : null;
+    }
+}

--- a/src/main/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/repository/refund/RefundRepository.java
+++ b/src/main/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/repository/refund/RefundRepository.java
@@ -41,7 +41,7 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
     where (:refundStatus is null or r.refundStatus = :refundStatus)
       and (:from is null or r.refundCreatedAt >= :from)
       and (:to is null or r.refundCreatedAt < :to)
-      and (:userId is null or o.userId = :userId)
+      and (:userId is null or o.userId in :userIds)
       and (:orderNumber is null or o.orderNumber like concat('%', :orderNumber, '%'))
       and (
             :includeGuest = true
@@ -52,7 +52,7 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
             @Param("refundStatus") RefundStatus refundStatus,
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to,
-            @Param("userId") Long userId,
+            @Param("userIds") List<Long> userIds,
             @Param("orderNumber") String orderNumber,
             @Param("includeGuest") boolean includeGuest,
             Pageable pageable

--- a/src/main/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/service/RefundService.java
+++ b/src/main/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/service/RefundService.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.Book2OnAndOn_order_payment_service.order.service;
 
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundGuestRequestDto;
+import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundSearchCondition;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.response.RefundAvailableItemResponseDto;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundRequestDto;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.response.RefundResponseDto;
@@ -45,13 +46,7 @@ public interface RefundService {
 
 
     // 8) 관리자 반품 목록 조회
-    Page<RefundResponseDto> getRefundListForAdmin(RefundStatus refundStatus,
-                                                  LocalDate startDate,
-                                                  LocalDate endDate,
-                                                  Long userId,
-                                                  String userKeyword,
-                                                  String orderNumber,
-                                                  boolean includeGuest,
+    Page<RefundResponseDto> getRefundListForAdmin(RefundSearchCondition condition,
                                                   Pageable pageable
     );
 

--- a/src/main/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/service/RefundServiceImpl.java
+++ b/src/main/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/service/RefundServiceImpl.java
@@ -9,6 +9,7 @@ import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.Refund
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundGuestRequestDto;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundItemRequestDto;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundRequestDto;
+import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundSearchCondition;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundStatusUpdateRequestDto;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.response.RefundAvailableItemResponseDto;
 import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.response.RefundItemResponseDto;
@@ -48,6 +49,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
@@ -549,38 +551,34 @@ public class RefundServiceImpl implements RefundService {
     }
 
     @Override
-    public Page<RefundResponseDto> getRefundListForAdmin(
-            RefundStatus refundStatus,
-            LocalDate startDate,
-            LocalDate endDate,
-            Long userId,
-            String userKeyword,
-            String orderNumber,
-            boolean includeGuest,
-            Pageable pageable
-    ) {
-        LocalDateTime from = (startDate != null) ? startDate.atStartOfDay() : null;
-        LocalDateTime to = (endDate != null) ? endDate.plusDays(1).atStartOfDay() : null;
+    @Transactional(readOnly = true) //읽기전용으로 전환 (이렇게 하면 DB 변경감지(dirty checking)을 안하기 때문에 성능이 빨라짐 굿굿!
+    public Page<RefundResponseDto> getRefundListForAdmin(RefundSearchCondition condition, Pageable pageable) {
+        //검색 조건 준비
+        //1. 날짜 조건 변환
+        LocalDateTime from = (condition.getStartDate() != null) ? condition.getStartDate().atStartOfDay() : null;
+        LocalDateTime to = (condition.getEndDate() != null) ? condition.getEndDate().plusDays(1).atStartOfDay() : null;
 
-        Long effectiveUserId = userId;
-        if (effectiveUserId == null && userKeyword != null && !userKeyword.isBlank()) {
-            List<Long> ids = userServiceClient.searchUserIdsByKeyword(userKeyword.trim());
-            if (ids.size() == 1) {
-                effectiveUserId = ids.get(0);
+        //2. 유저 검색 조건 처리
+        List<Long> userIds = null;
+
+        //2.1 userId 하나가 직접 들어온 경우는 우선순위 높음 처리해야함
+        if(condition.getUserId() != null){
+            userIds = List.of(condition.getUserId());
+        }else if(StringUtils.hasText(condition.getUserKeyword())){ //2.2 userKeyword(이름/이메일 등)이 들어온 경우 Feign Client호출
+            userIds = userServiceClient.searchUserIdsByKeyword(condition.getUserKeyword());
+            if(userIds == null || userIds.isEmpty()){ //키워드로 검색했는데 유저가 한 명도 없으면 -> 결과도 없어야함 (DB 조회 불필요)
+                return Page.empty(pageable);
             }
         }
-
-        String normalizedOrderNumber = (orderNumber != null && !orderNumber.isBlank())
-                ? orderNumber.trim() : null;
-
         // 주의: orderNumber 부분일치(like)는 repository query에서 구현되어야 함
+        // 3. Repository 호출
         Page<Refund> refundPage = refundRepository.searchRefunds(
-                refundStatus,
+                condition.getRefundStatusEnum(),
                 from,
                 to,
-                effectiveUserId,
-                normalizedOrderNumber,
-                includeGuest,
+                userIds,  //List<Long> 으로 변경
+                condition.getOrderNumber(),
+                condition.isIncludeGuest(),
                 pageable
         );
 

--- a/src/test/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/service/RefundServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/Book2OnAndOn_order_payment_service/order/service/RefundServiceImplTest.java
@@ -1,0 +1,99 @@
+package com.nhnacademy.Book2OnAndOn_order_payment_service.order.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.nhnacademy.Book2OnAndOn_order_payment_service.client.UserServiceClient;
+import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.request.RefundSearchCondition;
+import com.nhnacademy.Book2OnAndOn_order_payment_service.order.dto.refund.response.RefundResponseDto;
+import com.nhnacademy.Book2OnAndOn_order_payment_service.order.entity.refund.Refund;
+import com.nhnacademy.Book2OnAndOn_order_payment_service.order.entity.refund.RefundReason;
+import com.nhnacademy.Book2OnAndOn_order_payment_service.order.entity.refund.RefundStatus;
+import com.nhnacademy.Book2OnAndOn_order_payment_service.order.repository.refund.RefundRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+
+@ExtendWith(MockitoExtension.class)
+class RefundServiceImplTest {
+    @InjectMocks
+    RefundServiceImpl refundService;
+
+    @Mock
+    RefundRepository refundRepository;
+
+    @Mock
+    UserServiceClient userServiceClient;
+
+    @Test
+    @DisplayName("관리자 검색: 유저 키워드로 검색했지만 결과 없으면 DB 조회 없이 빈 페이지 반환해야함")
+    void search_with_keyword_no_result() {
+        RefundSearchCondition condition = new RefundSearchCondition();
+        condition.setUserKeyword("존재하지않는유저");
+        Pageable pageable = PageRequest.of(0, 10);
+
+        given(userServiceClient.searchUserIdsByKeyword("존재하지않는유저"))
+                .willReturn(Collections.emptyList());
+
+        Page<RefundResponseDto> result = refundService.getRefundListForAdmin(condition, pageable);
+
+        assertThat(result.isEmpty()).isTrue();
+
+        verify(refundRepository, never()).searchRefunds(any(), any(), any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    @DisplayName("관리자 검색: 날짜 및 유저 키워드 정상 검색")
+    void search_normal() {
+        RefundSearchCondition condition = new RefundSearchCondition();
+        condition.setStartDate(LocalDate.of(2025, 1, 1));
+        condition.setEndDate(LocalDate.of(2025, 1, 31));
+        condition.setUserKeyword("홍길동");
+
+        List<Long> mockUserIds = List.of(1L, 2L);
+        given(userServiceClient.searchUserIdsByKeyword("홍길동")).willReturn(mockUserIds);
+
+        Refund mockRefund = mock(Refund.class);
+
+        given(mockRefund.getRefundItems()).willReturn(Collections.emptyList());
+
+        given(mockRefund.getRefundReason()).willReturn(RefundReason.OTHER);
+        given(mockRefund.getRefundStatus()).willReturn(RefundStatus.REQUESTED);
+
+        Page<Refund> mockPage = new PageImpl<>(List.of(mockRefund));
+        given(refundRepository.searchRefunds(
+                eq(null), // status
+                eq(LocalDateTime.of(2025, 1, 1, 0, 0, 0)), // start
+                eq(LocalDateTime.of(2025, 2, 1, 0, 0, 0)), // end (plusDays(1) 확인)
+                eq(mockUserIds), // userIds 리스트 전달 확인
+                eq(null),
+                eq(true),
+                any(Pageable.class)
+        )).willReturn(mockPage);
+
+        refundService.getRefundListForAdmin(condition, PageRequest.of(0, 10));
+
+
+        verify(refundRepository, times(1)).searchRefunds(any(), any(), any(), any(), any(), anyBoolean(), any());
+    }
+}


### PR DESCRIPTION
## 🔀 PR 개요

관리자 반품 목록 조회 API의 구조를 개선하고, 검색 편의성을 높이기 위해 유저 키워드(이름 등) 검색 기능을 추가했습니다.

- DTO 도입: 비대해진 파라미터를 객체(RefundSearchCondition)로 캡슐화

- 기능 확장: userId뿐만 아니라 userKeyword(이름/이메일)로도 검색 가능하도록 개선

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

- [x] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [x] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [x] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)


**1. 검색 조건 DTO(RefundSearchCondition) 적용**

- Controller/Service 계층에서 8개의 @RequestParam을 나열하던 방식을 제거하고 DTO로 통합하여 확장성을 확보했습니다.

- DTO 내부에서 RefundStatus Enum 변환 로직을 캡슐화했습니다.

**2. 유저 키워드 검색 로직 구현 (RefundServiceImpl)**

- userKeyword 파라미터 수신 시 UserServiceClient를 호출하여 해당하는 유저 ID 목록(List<Long>)을 조회합니다.

- 최적화: 키워드 검색 결과가 없는 경우, DB를 조회하지 않고 즉시 빈 페이지(Page.empty())를 반환하도록 처리했습니다.

**3. Repository 동적 쿼리 개선 (RefundRepository)**

- 단일 userId 조회만 가능했던 JPQL을 IN 절((:userIds is null or o.userId in :userIds))을 사용하여 다중 조회도 지원하도록 수정했습니다.

- LocalDate 파라미터를 LocalDateTime으로 정확히 변환하여 조회 기간의 경계값(Boundary) 문제를 해결했습니다.

**4. 테스트 코드 작성**

- Refund 엔티티의 protected 생성자 제약을 고려하여 Mockito(mock(Refund.class))를 활용한 Service 단위 테스트를 작성했습니다.

---

## 💡 변경 이유

**유지보수성 저하 해결**: 관리자 검색 조건이 늘어날 때마다 Controller, Service, Repository의 메서드 시그니처를 모두 수정해야 하는 "Long Parameter List" 문제를 해결하기 위해 DTO 패턴을 도입했습니다.

**검색 편의성 증대**: 기존에는 관리자가 회원의 userId(Long)를 정확히 알아야만 검색이 가능했습니다. 이를 보완하기 위해 이름이나 이메일 같은 키워드로 검색할 수 있는 기능이 필수적이었습니다.

**확장성 확보**: 향후 '결제 수단', '상품명' 등 필터가 추가되더라도 DTO 필드만 추가하면 되므로 변경에 유연하게 대처할 수 있습니다.

---

## 🧩 관련 이슈

- Closes #133 

---

## 🧪 테스트 방법

**1. Service 단위 테스트 실행 RefundServiceImplTest를 실행하여 다음 로직을 검증합니다.**

- 키워드 검색 시 User Service 호출 여부
- 검색된 유저가 없을 때 DB 조회 없이 빈 결과 반환 여부
- 날짜 범위(endDate + 1일) 변환 로직 정상 동작 여부

**2. API 통합 테스트**

```Bash
# 1. 유저 키워드 검색 (정상 케이스)
GET /admin/refunds?userKeyword=홍길동&startDate=2025-01-01&endDate=2025-01-31&page=0&size=10
 -> 결과: User Service에서 '홍길동' ID 목록을 받아와 반품 내역 조회

# 2. 존재하지 않는 유저 검색 (최적화 검증)
GET /admin/refunds?userKeyword=없는사람
 -> 결과: DB 쿼리 없이 빈 리스트([]) 반환
 ```